### PR TITLE
Add capistrano dry run support

### DIFF
--- a/spec/integration/capistrano/template/helpers/dsl_spec.rb
+++ b/spec/integration/capistrano/template/helpers/dsl_spec.rb
@@ -58,6 +58,10 @@ module Capistrano
 
             def error(*)
             end
+
+            def dry_run?
+              false
+            end
           end
         end
       end

--- a/spec/unit/capistrano/template/helpers/dsl_dry_run_spec.rb
+++ b/spec/unit/capistrano/template/helpers/dsl_dry_run_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+module Capistrano
+  module Template
+    module Helpers
+      module Unit # protect from other dummy classes
+        module DSLSpec
+          class DummyDryRun
+            include DSL
+            def template_exists?
+              true
+            end
+
+            def dry_run?
+              true
+            end
+          end
+        end
+      end
+
+      describe DSL do
+        subject do
+          Unit::DSLSpec::DummyDryRun.new
+        end
+
+        describe '#template dry run' do
+          it 'do nothing' do
+            expect(subject).not_to receive(:_template_factory)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
When i use Capistrano with the dry-run option capistrano-template failed 

``` log
The deploy has failed with an error: undefined method `template' for #<SSHKit::Backend::Printer:0x00000002769358>
```
If capistrano is run in dry-run mode i doesn't create the template.