### PR TITLE
Fix ruby 2.7.0 deprecation warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,5 @@ rvm:
 script: bundle exec rake spec rubocop
 cache: bundler
 before_install:
-  - gem install bundler # -v 1.7.14 if a specific version is needed
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v '< 2'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
   - 2.2.1
   - 2.3.1
   - 2.4.0
+  - 2.7.0
 script: bundle exec rake spec rubocop
 cache: bundler
 before_install:

--- a/.versions.conf
+++ b/.versions.conf
@@ -1,4 +1,4 @@
-ruby=ruby-2.4.0
+ruby=ruby-2.7.0
 ruby-gemset=capistrano-template
 #ruby-gem-install=bundler rake
 #ruby-bundle-install=true

--- a/lib/capistrano/template/helpers/dsl.rb
+++ b/lib/capistrano/template/helpers/dsl.rb
@@ -37,7 +37,7 @@ module Capistrano
         end
 
         def _uploader_factory
-          ->(*args) { Uploader.new(*args) }
+          ->(*args, **options) { Uploader.new(*args, **options) }
         end
 
         def _paths_factory


### PR DESCRIPTION
After update to ruby 2.7.0 I start getting this warning:

```
capistrano-template-0.0.9/lib/capistrano/template/helpers/dsl.rb:40: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
capistrano-template-0.0.9/lib/capistrano/template/helpers/uploader.rb:21: warning: The called method `initialize' is defined here
```